### PR TITLE
Handle hours in duration formatting

### DIFF
--- a/Sales Tracker/Classes/Tools.cs
+++ b/Sales Tracker/Classes/Tools.cs
@@ -43,8 +43,15 @@ namespace Sales_Tracker.Classes
                 return $"{timespan.TotalSeconds:F2}s";
             }
 
-            // For longer durations
-            return $"{timespan.Minutes}m {timespan.Seconds}s";
+            // For durations less than 1 hour
+            if (timespan.TotalHours < 1)
+            {
+                return $"{timespan.Minutes}m {timespan.Seconds}s";
+            }
+
+            // For durations of 1 hour or more
+            int hours = (int)timespan.TotalHours;
+            return $"{hours}h {timespan.Minutes}m {timespan.Seconds}s";
         }
 
         // General

--- a/Tests/Tools_UnitTest.cs
+++ b/Tests/Tools_UnitTest.cs
@@ -81,6 +81,14 @@ namespace Tests
         }
 
         [TestMethod]
+        public void TestFormatDurationHours()
+        {
+            long duration = 3725000; // 1 hour, 2 minutes and 5 seconds
+            string result = Tools.FormatDuration(duration);
+            Assert.AreEqual("1h 2m 5s", result);
+        }
+
+        [TestMethod]
         public void TestConvertBytesToReadableSize()
         {
             // Test bytes


### PR DESCRIPTION
## Summary
- ensure Tools.FormatDuration displays hours when durations exceed 1 hour
- add unit test covering hour-level durations

## Testing
- `dotnet test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68accc41152083258cfd5a8beb846ec0