### PR TITLE
Update LiveCharts. Closes #280 & #301

### DIFF
--- a/Sales Tracker/ApplicationStartup.cs
+++ b/Sales Tracker/ApplicationStartup.cs
@@ -1,12 +1,10 @@
-﻿using LiveChartsCore.SkiaSharpView;
-using Microsoft.Win32;
+﻿using Microsoft.Win32;
 using Sales_Tracker.Classes;
 using Sales_Tracker.Encryption;
 using Sales_Tracker.Language;
 using Sales_Tracker.Passwords;
 using Sales_Tracker.Theme;
 using Sales_Tracker.UI;
-using SkiaSharp;
 
 namespace Sales_Tracker
 {
@@ -66,7 +64,6 @@ namespace Sales_Tracker
             LicenseManager licenseManager = new();
             _ = licenseManager.ValidateKeyAsync();
 
-            SetLiveChartTitleFont();
             RegisterFileAssociationOnFirstRun();
 
             if (AutoOpenAfterUpdate)
@@ -160,19 +157,6 @@ namespace Sales_Tracker
                     Log.WriteWithFormat(0, "Translations update completed with failures");
                 }
             }
-        }
-
-        /// <summary>
-        /// Configures LiveCharts font for proper Unicode text rendering, fixing the rendering of non-Latin languages.
-        /// </summary>
-        private static void SetLiveChartTitleFont()
-        {
-            // I use "Segoe UI" for my app, but for some reason it doesn't work here. "Nirmala UI" seems to work for most languages.
-            LiveChartsCore.LiveCharts.Configure(config => config
-                .AddSkiaSharp()
-                .AddDefaultMappers()
-                .HasGlobalSKTypeface(SKTypeface.FromFamilyName("Nirmala UI"))
-            );
         }
 
         /// <summary>

--- a/Sales Tracker/Charts/ChartData.cs
+++ b/Sales Tracker/Charts/ChartData.cs
@@ -1,4 +1,4 @@
-﻿namespace Sales_Tracker.DataClasses
+﻿namespace Sales_Tracker.Charts
 {
     /// <summary>
     /// Represents chart data containing a total value and associated data points for visualization.

--- a/Sales Tracker/Charts/RightClickGunaChartMenu.cs
+++ b/Sales Tracker/Charts/RightClickGunaChartMenu.cs
@@ -94,89 +94,89 @@ namespace Sales_Tracker.Charts
             switch (chart.Tag)
             {
                 case MainMenu_Form.ChartDataType.TotalSales:
-                    LoadChart.LoadTotalsIntoChart(MainMenu_Form.Instance.Sale_DataGridView, GetCartesianChart(MainMenu_Form.Instance.SaleTotals_Chart), isLine, true, directory);
+                    LoadChart.LoadTotalsIntoChart(MainMenu_Form.Instance.Sale_DataGridView, MainMenu_Form.Instance.SaleTotals_Chart, isLine, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.TotalPurchases:
-                    LoadChart.LoadTotalsIntoChart(MainMenu_Form.Instance.Purchase_DataGridView, GetCartesianChart(MainMenu_Form.Instance.PurchaseTotals_Chart), isLine, true, directory);
+                    LoadChart.LoadTotalsIntoChart(MainMenu_Form.Instance.Purchase_DataGridView, MainMenu_Form.Instance.PurchaseTotals_Chart, isLine, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.DistributionOfSales:
-                    LoadChart.LoadDistributionIntoChart(MainMenu_Form.Instance.Sale_DataGridView, GetPieChart(MainMenu_Form.Instance.SaleDistribution_Chart), PieChartGrouping.Unlimited, true, directory);
+                    LoadChart.LoadDistributionIntoChart(MainMenu_Form.Instance.Sale_DataGridView, MainMenu_Form.Instance.SaleDistribution_Chart, PieChartGrouping.Unlimited, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.DistributionOfPurchases:
-                    LoadChart.LoadDistributionIntoChart(MainMenu_Form.Instance.Purchase_DataGridView, GetPieChart(MainMenu_Form.Instance.PurchaseDistribution_Chart), PieChartGrouping.Unlimited, true, directory);
+                    LoadChart.LoadDistributionIntoChart(MainMenu_Form.Instance.Purchase_DataGridView, MainMenu_Form.Instance.PurchaseDistribution_Chart, PieChartGrouping.Unlimited, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.TotalProfits:
-                    LoadChart.LoadProfitsIntoChart(GetCartesianChart(MainMenu_Form.Instance.Profits_Chart), isLine, true, directory);
+                    LoadChart.LoadProfitsIntoChart(MainMenu_Form.Instance.Profits_Chart, isLine, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.CountriesOfOrigin:
-                    LoadChart.LoadCountriesOfOriginForProductsIntoChart(GetPieChart(MainMenu_Form.Instance.CountriesOfOrigin_Chart), PieChartGrouping.Unlimited, true, directory);
+                    LoadChart.LoadCountriesOfOriginForProductsIntoChart(MainMenu_Form.Instance.CountriesOfOrigin_Chart, PieChartGrouping.Unlimited, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.CompaniesOfOrigin:
-                    LoadChart.LoadCompaniesOfOriginForProductsIntoChart(GetPieChart(MainMenu_Form.Instance.CompaniesOfOrigin_Chart), PieChartGrouping.Unlimited, true, directory);
+                    LoadChart.LoadCompaniesOfOriginForProductsIntoChart(MainMenu_Form.Instance.CompaniesOfOrigin_Chart, PieChartGrouping.Unlimited, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.CountriesOfDestination:
-                    LoadChart.LoadCountriesOfDestinationForProductsIntoChart(GetPieChart(MainMenu_Form.Instance.CountriesOfDestination_Chart), PieChartGrouping.Unlimited, true, directory);
+                    LoadChart.LoadCountriesOfDestinationForProductsIntoChart(MainMenu_Form.Instance.CountriesOfDestination_Chart, PieChartGrouping.Unlimited, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.Accountants:
-                    LoadChart.LoadAccountantsIntoChart(GetPieChart(MainMenu_Form.Instance.Accountants_Chart), PieChartGrouping.Unlimited, true, directory);
+                    LoadChart.LoadAccountantsIntoChart(MainMenu_Form.Instance.Accountants_Chart, PieChartGrouping.Unlimited, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.TotalExpensesVsSales:
-                    LoadChart.LoadSalesVsExpensesChart(GetCartesianChart(MainMenu_Form.Instance.SalesVsExpenses_Chart), isLine, true, directory);
+                    LoadChart.LoadSalesVsExpensesChart(MainMenu_Form.Instance.SalesVsExpenses_Chart, isLine, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.AverageOrderValue:
-                    LoadChart.LoadAverageTransactionValueChart(GetCartesianChart(MainMenu_Form.Instance.AverageTransactionValue_Chart), isLine, true, directory);
+                    LoadChart.LoadAverageTransactionValueChart(MainMenu_Form.Instance.AverageTransactionValue_Chart, isLine, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.TotalTransactions:
-                    LoadChart.LoadTotalTransactionsChart(GetCartesianChart(MainMenu_Form.Instance.TotalTransactions_Chart), isLine, true, directory);
+                    LoadChart.LoadTotalTransactionsChart(MainMenu_Form.Instance.TotalTransactions_Chart, isLine, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.AverageShippingCosts:
-                    LoadChart.LoadAverageShippingCostsChart(GetCartesianChart(MainMenu_Form.Instance.AverageShippingCosts_Chart), isLine, true, directory);
+                    LoadChart.LoadAverageShippingCostsChart(MainMenu_Form.Instance.AverageShippingCosts_Chart, isLine, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.GrowthRates:
-                    LoadChart.LoadGrowthRateChart(GetCartesianChart(MainMenu_Form.Instance.GrowthRates_Chart), true, directory);
+                    LoadChart.LoadGrowthRateChart(MainMenu_Form.Instance.GrowthRates_Chart, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.ReturnsOverTime:
-                    LoadChart.LoadReturnsOverTimeChart(GetCartesianChart(MainMenu_Form.Instance.ReturnsOverTime_Chart), isLine, true, directory);
+                    LoadChart.LoadReturnsOverTimeChart(MainMenu_Form.Instance.ReturnsOverTime_Chart, isLine, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.ReturnReasons:
-                    LoadChart.LoadReturnReasonsChart(GetPieChart(MainMenu_Form.Instance.ReturnReasons_Chart), PieChartGrouping.Unlimited, true, directory);
+                    LoadChart.LoadReturnReasonsChart(MainMenu_Form.Instance.ReturnReasons_Chart, PieChartGrouping.Unlimited, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.ReturnFinancialImpact:
-                    LoadChart.LoadReturnFinancialImpactChart(GetCartesianChart(MainMenu_Form.Instance.ReturnFinancialImpact_Chart), isLine, true, directory);
+                    LoadChart.LoadReturnFinancialImpactChart(MainMenu_Form.Instance.ReturnFinancialImpact_Chart, isLine, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.ReturnsByCategory:
-                    LoadChart.LoadReturnsByCategoryChart(GetPieChart(MainMenu_Form.Instance.ReturnsByCategory_Chart), PieChartGrouping.Unlimited, true, directory);
+                    LoadChart.LoadReturnsByCategoryChart(MainMenu_Form.Instance.ReturnsByCategory_Chart, PieChartGrouping.Unlimited, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.ReturnsByProduct:
-                    LoadChart.LoadReturnsByProductChart(GetPieChart(MainMenu_Form.Instance.ReturnsByProduct_Chart), PieChartGrouping.Unlimited, true, directory);
+                    LoadChart.LoadReturnsByProductChart(MainMenu_Form.Instance.ReturnsByProduct_Chart, PieChartGrouping.Unlimited, true, directory);
                     break;
 
                 case MainMenu_Form.ChartDataType.PurchaseVsSaleReturns:
-                    LoadChart.LoadPurchaseVsSaleReturnsChart(GetPieChart(MainMenu_Form.Instance.PurchaseVsSaleReturns_Chart), true, directory);
+                    LoadChart.LoadPurchaseVsSaleReturnsChart(MainMenu_Form.Instance.PurchaseVsSaleReturns_Chart, true, directory);
                     break;
             }
         }
         private static async void ExportToGoogleSheets(object sender, EventArgs e)
         {
-            Chart chart = (Chart)RightClickGunaChart_Panel.Tag;
+            Control chart = (Control)RightClickGunaChart_Panel.Tag;
             bool isLine = MainMenu_Form.Instance.LineChart_ToggleSwitch.Checked;
 
             try
@@ -185,7 +185,7 @@ namespace Sales_Tracker.Charts
                 {
                     case MainMenu_Form.ChartDataType.TotalSales:
                         {
-                            ChartData chartData = LoadChart.LoadTotalsIntoChart(MainMenu_Form.Instance.Sale_DataGridView, GetCartesianChart(MainMenu_Form.Instance.SaleTotals_Chart), isLine, canUpdateChart: false);
+                            ChartData chartData = LoadChart.LoadTotalsIntoChart(MainMenu_Form.Instance.Sale_DataGridView, MainMenu_Form.Instance.SaleTotals_Chart, isLine, canUpdateChart: false);
                             string chartTitle = TranslatedChartTitles.TotalRevenue;
                             GoogleSheetManager.ChartType chartType = isLine
                                 ? GoogleSheetManager.ChartType.Line
@@ -199,7 +199,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.TotalPurchases:
                         {
-                            ChartData chartData = LoadChart.LoadTotalsIntoChart(MainMenu_Form.Instance.Purchase_DataGridView, GetCartesianChart(MainMenu_Form.Instance.PurchaseTotals_Chart), isLine, canUpdateChart: false);
+                            ChartData chartData = LoadChart.LoadTotalsIntoChart(MainMenu_Form.Instance.Purchase_DataGridView, MainMenu_Form.Instance.PurchaseTotals_Chart, isLine, canUpdateChart: false);
                             string chartTitle = TranslatedChartTitles.TotalExpenses;
                             GoogleSheetManager.ChartType chartType = isLine
                                 ? GoogleSheetManager.ChartType.Line
@@ -213,7 +213,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.DistributionOfSales:
                         {
-                            ChartData chartData = LoadChart.LoadDistributionIntoChart(MainMenu_Form.Instance.Sale_DataGridView, GetPieChart(MainMenu_Form.Instance.SaleDistribution_Chart), PieChartGrouping.Unlimited, canUpdateChart: false);
+                            ChartData chartData = LoadChart.LoadDistributionIntoChart(MainMenu_Form.Instance.Sale_DataGridView, MainMenu_Form.Instance.SaleDistribution_Chart, PieChartGrouping.Unlimited, canUpdateChart: false);
                             string chartTitle = TranslatedChartTitles.RevenueDistribution;
                             string first = LanguageManager.TranslateString("Category");
                             string second = LanguageManager.TranslateString("Revenue");
@@ -224,7 +224,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.DistributionOfPurchases:
                         {
-                            ChartData chartData = LoadChart.LoadDistributionIntoChart(MainMenu_Form.Instance.Purchase_DataGridView, GetPieChart(MainMenu_Form.Instance.PurchaseDistribution_Chart), PieChartGrouping.Unlimited, canUpdateChart: false);
+                            ChartData chartData = LoadChart.LoadDistributionIntoChart(MainMenu_Form.Instance.Purchase_DataGridView, MainMenu_Form.Instance.PurchaseDistribution_Chart, PieChartGrouping.Unlimited, canUpdateChart: false);
                             string chartTitle = TranslatedChartTitles.ExpensesDistribution;
                             string first = LanguageManager.TranslateString("Category");
                             string second = LanguageManager.TranslateString("Expenses");
@@ -235,7 +235,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.TotalProfits:
                         {
-                            ChartData chartData = LoadChart.LoadProfitsIntoChart(GetCartesianChart(MainMenu_Form.Instance.Profits_Chart), isLine, canUpdateChart: false);
+                            ChartData chartData = LoadChart.LoadProfitsIntoChart(MainMenu_Form.Instance.Profits_Chart, isLine, canUpdateChart: false);
                             string chartTitle = TranslatedChartTitles.TotalProfits;
                             GoogleSheetManager.ChartType chartType = isLine
                                 ? GoogleSheetManager.ChartType.Line
@@ -249,7 +249,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.CountriesOfOrigin:
                         {
-                            ChartData chartData = LoadChart.LoadCountriesOfOriginForProductsIntoChart(GetPieChart(MainMenu_Form.Instance.CountriesOfOrigin_Chart), PieChartGrouping.Unlimited, canUpdateChart: false);
+                            ChartData chartData = LoadChart.LoadCountriesOfOriginForProductsIntoChart(MainMenu_Form.Instance.CountriesOfOrigin_Chart, PieChartGrouping.Unlimited, canUpdateChart: false);
                             string chartTitle = TranslatedChartTitles.CountriesOfOrigin;
                             string first = LanguageManager.TranslateString("Countries");
                             string second = LanguageManager.TranslateString("# of items");
@@ -260,7 +260,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.CompaniesOfOrigin:
                         {
-                            ChartData chartData = LoadChart.LoadCompaniesOfOriginForProductsIntoChart(GetPieChart(MainMenu_Form.Instance.CompaniesOfOrigin_Chart), PieChartGrouping.Unlimited, canUpdateChart: false);
+                            ChartData chartData = LoadChart.LoadCompaniesOfOriginForProductsIntoChart(MainMenu_Form.Instance.CompaniesOfOrigin_Chart, PieChartGrouping.Unlimited, canUpdateChart: false);
                             string chartTitle = TranslatedChartTitles.CompaniesOfOrigin;
                             string first = LanguageManager.TranslateString("Companies");
                             string second = LanguageManager.TranslateString("# of items");
@@ -271,7 +271,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.CountriesOfDestination:
                         {
-                            ChartData chartData = LoadChart.LoadCountriesOfDestinationForProductsIntoChart(GetPieChart(MainMenu_Form.Instance.CountriesOfDestination_Chart), PieChartGrouping.Unlimited, canUpdateChart: false);
+                            ChartData chartData = LoadChart.LoadCountriesOfDestinationForProductsIntoChart(MainMenu_Form.Instance.CountriesOfDestination_Chart, PieChartGrouping.Unlimited, canUpdateChart: false);
                             string chartTitle = TranslatedChartTitles.CountriesOfDestination;
                             string first = LanguageManager.TranslateString("Countries");
                             string second = LanguageManager.TranslateString("# of items");
@@ -282,7 +282,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.Accountants:
                         {
-                            ChartData chartData = LoadChart.LoadAccountantsIntoChart(GetPieChart(MainMenu_Form.Instance.Accountants_Chart), PieChartGrouping.Unlimited, canUpdateChart: false);
+                            ChartData chartData = LoadChart.LoadAccountantsIntoChart(MainMenu_Form.Instance.Accountants_Chart, PieChartGrouping.Unlimited, canUpdateChart: false);
                             string chartTitle = TranslatedChartTitles.AccountantsTransactions;
                             string first = LanguageManager.TranslateString("Accountants");
                             string second = LanguageManager.TranslateString("# of transactions");
@@ -293,7 +293,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.TotalExpensesVsSales:
                         {
-                            SalesExpensesChartData salesExpensesData = LoadChart.LoadSalesVsExpensesChart(GetCartesianChart(MainMenu_Form.Instance.SalesVsExpenses_Chart), isLine, canUpdateChart: false);
+                            SalesExpensesChartData salesExpensesData = LoadChart.LoadSalesVsExpensesChart(MainMenu_Form.Instance.SalesVsExpenses_Chart, isLine, canUpdateChart: false);
                             Dictionary<string, Dictionary<string, double>> combinedData = [];
 
                             foreach (string date in salesExpensesData.GetDateOrder())
@@ -316,7 +316,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.AverageOrderValue:
                         {
-                            SalesExpensesChartData chartData = LoadChart.LoadAverageTransactionValueChart(GetCartesianChart(MainMenu_Form.Instance.AverageTransactionValue_Chart), isLine, canUpdateChart: false);
+                            SalesExpensesChartData chartData = LoadChart.LoadAverageTransactionValueChart(MainMenu_Form.Instance.AverageTransactionValue_Chart, isLine, canUpdateChart: false);
                             Dictionary<string, Dictionary<string, double>> combinedData = [];
 
                             foreach (string date in chartData.GetDateOrder())
@@ -339,7 +339,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.TotalTransactions:
                         {
-                            SalesExpensesChartData chartData = LoadChart.LoadTotalTransactionsChart(GetCartesianChart(MainMenu_Form.Instance.TotalTransactions_Chart), isLine, canUpdateChart: false);
+                            SalesExpensesChartData chartData = LoadChart.LoadTotalTransactionsChart(MainMenu_Form.Instance.TotalTransactions_Chart, isLine, canUpdateChart: false);
                             Dictionary<string, Dictionary<string, double>> combinedData = [];
 
                             foreach (string date in chartData.GetDateOrder())
@@ -362,7 +362,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.AverageShippingCosts:
                         {
-                            SalesExpensesChartData chartData = LoadChart.LoadAverageShippingCostsChart(GetCartesianChart(MainMenu_Form.Instance.AverageShippingCosts_Chart), isLine, canUpdateChart: false);
+                            SalesExpensesChartData chartData = LoadChart.LoadAverageShippingCostsChart(MainMenu_Form.Instance.AverageShippingCosts_Chart, isLine, canUpdateChart: false);
                             Dictionary<string, Dictionary<string, double>> combinedData = [];
 
                             foreach (string date in chartData.GetDateOrder())
@@ -385,7 +385,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.GrowthRates:
                         {
-                            SalesExpensesChartData chartData = LoadChart.LoadGrowthRateChart(GetCartesianChart(MainMenu_Form.Instance.GrowthRates_Chart), exportToExcel: false, filePath: null, canUpdateChart: false);
+                            SalesExpensesChartData chartData = LoadChart.LoadGrowthRateChart(MainMenu_Form.Instance.GrowthRates_Chart, exportToExcel: false, filePath: null, canUpdateChart: false);
                             Dictionary<string, Dictionary<string, double>> combinedData = [];
 
                             foreach (string date in chartData.GetDateOrder())
@@ -406,7 +406,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.ReturnsOverTime:
                         {
-                            SalesExpensesChartData chartData = LoadChart.LoadReturnsOverTimeChart(GetCartesianChart(MainMenu_Form.Instance.ReturnsOverTime_Chart), isLine, canUpdateChart: false);
+                            SalesExpensesChartData chartData = LoadChart.LoadReturnsOverTimeChart(MainMenu_Form.Instance.ReturnsOverTime_Chart, isLine, canUpdateChart: false);
                             Dictionary<string, Dictionary<string, double>> combinedData = [];
 
                             foreach (string date in chartData.GetDateOrder())
@@ -429,7 +429,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.ReturnReasons:
                         {
-                            ChartCountData chartData = LoadChart.LoadReturnReasonsChart(GetPieChart(MainMenu_Form.Instance.ReturnReasons_Chart), PieChartGrouping.Unlimited, canUpdateChart: false);
+                            ChartCountData chartData = LoadChart.LoadReturnReasonsChart(MainMenu_Form.Instance.ReturnReasons_Chart, PieChartGrouping.Unlimited, canUpdateChart: false);
                             string chartTitle = TranslatedChartTitles.ReturnReasons;
                             string first = LanguageManager.TranslateString("Reasons");
                             string second = LanguageManager.TranslateString("# of returns");
@@ -440,7 +440,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.ReturnFinancialImpact:
                         {
-                            SalesExpensesChartData chartData = LoadChart.LoadReturnFinancialImpactChart(GetCartesianChart(MainMenu_Form.Instance.ReturnFinancialImpact_Chart), isLine, canUpdateChart: false);
+                            SalesExpensesChartData chartData = LoadChart.LoadReturnFinancialImpactChart(MainMenu_Form.Instance.ReturnFinancialImpact_Chart, isLine, canUpdateChart: false);
                             Dictionary<string, Dictionary<string, double>> combinedData = [];
 
                             foreach (string date in chartData.GetDateOrder())
@@ -463,7 +463,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.ReturnsByCategory:
                         {
-                            ChartCountData chartData = LoadChart.LoadReturnsByCategoryChart(GetPieChart(MainMenu_Form.Instance.ReturnsByCategory_Chart), PieChartGrouping.Unlimited, canUpdateChart: false);
+                            ChartCountData chartData = LoadChart.LoadReturnsByCategoryChart(MainMenu_Form.Instance.ReturnsByCategory_Chart, PieChartGrouping.Unlimited, canUpdateChart: false);
                             string chartTitle = TranslatedChartTitles.ReturnsByCategory;
                             string first = LanguageManager.TranslateString("Categories");
                             string second = LanguageManager.TranslateString("# of returns");
@@ -474,7 +474,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.ReturnsByProduct:
                         {
-                            ChartCountData chartData = LoadChart.LoadReturnsByProductChart(GetPieChart(MainMenu_Form.Instance.ReturnsByProduct_Chart), PieChartGrouping.Unlimited, canUpdateChart: false);
+                            ChartCountData chartData = LoadChart.LoadReturnsByProductChart(MainMenu_Form.Instance.ReturnsByProduct_Chart, PieChartGrouping.Unlimited, canUpdateChart: false);
                             string chartTitle = TranslatedChartTitles.ReturnsByProduct;
                             string first = LanguageManager.TranslateString("Products");
                             string second = LanguageManager.TranslateString("# of returns");
@@ -485,7 +485,7 @@ namespace Sales_Tracker.Charts
 
                     case MainMenu_Form.ChartDataType.PurchaseVsSaleReturns:
                         {
-                            ChartCountData chartData = LoadChart.LoadPurchaseVsSaleReturnsChart(GetPieChart(MainMenu_Form.Instance.PurchaseVsSaleReturns_Chart), canUpdateChart: false);
+                            ChartCountData chartData = LoadChart.LoadPurchaseVsSaleReturnsChart(MainMenu_Form.Instance.PurchaseVsSaleReturns_Chart, canUpdateChart: false);
                             string chartTitle = TranslatedChartTitles.PurchaseVsSaleReturns;
                             string first = LanguageManager.TranslateString("Transaction Type");
                             string second = LanguageManager.TranslateString("# of returns");
@@ -507,7 +507,7 @@ namespace Sales_Tracker.Charts
         }
         private static void ResetZoom(object sender, EventArgs e)
         {
-            Chart chart = (Chart)RightClickGunaChart_Panel.Tag;
+            Control chart = (Control)RightClickGunaChart_Panel.Tag;
 
             if (chart is CartesianChart cartesianChart)
             {
@@ -630,16 +630,6 @@ namespace Sales_Tracker.Charts
                 return labelVisual.Text;
             }
             return null;
-        }
-
-        // Helper methods to safely cast charts for LoadChart methods
-        private static CartesianChart GetCartesianChart(Chart chart)
-        {
-            return chart as CartesianChart ?? throw new ArgumentException("Expected CartesianChart", nameof(chart));
-        }
-        private static PieChart GetPieChart(Chart chart)
-        {
-            return chart as PieChart ?? throw new ArgumentException("Expected PieChart", nameof(chart));
         }
     }
 }

--- a/Sales Tracker/MainMenu_Form.cs
+++ b/Sales Tracker/MainMenu_Form.cs
@@ -85,23 +85,23 @@ namespace Sales_Tracker
         }
         private void ConstructMainCharts()
         {
-            PurchaseTotals_Chart = ConstructMainChart("purchaseTotals_Chart", true);
-            PurchaseDistribution_Chart = ConstructMainChart("purchaseDistribution_Chart", false);
-            SaleTotals_Chart = ConstructMainChart("saleTotals_Chart", true);
-            SaleDistribution_Chart = ConstructMainChart("saleDistribution_Chart", false);
-            Profits_Chart = ConstructMainChart("profits_Chart", true);
+            PurchaseTotals_Chart = ConstructMainChart("purchaseTotals_Chart", true) as CartesianChart;
+            PurchaseDistribution_Chart = ConstructMainChart("purchaseDistribution_Chart", false) as PieChart;
+            SaleTotals_Chart = ConstructMainChart("saleTotals_Chart", true) as CartesianChart;
+            SaleDistribution_Chart = ConstructMainChart("saleDistribution_Chart", false) as PieChart;
+            Profits_Chart = ConstructMainChart("profits_Chart", true) as CartesianChart;
 
-            LoadChart.ConfigureChartForPie(PurchaseDistribution_Chart as PieChart);
-            LoadChart.ConfigureChartForPie(SaleDistribution_Chart as PieChart);
+            LoadChart.ConfigureChartForPie(PurchaseDistribution_Chart);
+            LoadChart.ConfigureChartForPie(SaleDistribution_Chart);
 
             MouseClickChartManager.InitCharts([
                 PurchaseTotals_Chart, PurchaseDistribution_Chart,
                 SaleTotals_Chart, SaleDistribution_Chart, Profits_Chart
             ]);
         }
-        private Chart ConstructMainChart(string name, bool isCartesian)
+        private Control ConstructMainChart(string name, bool isCartesian)
         {
-            Chart chart;
+            Control chart;
 
             if (isCartesian)
             {
@@ -202,13 +202,13 @@ namespace Sales_Tracker
             // Load purchase charts
             if (Selected == SelectedOption.Analytics || Purchase_DataGridView.Visible)
             {
-                ChartData totalsData = LoadChart.LoadTotalsIntoChart(Purchase_DataGridView, PurchaseTotals_Chart as CartesianChart, isLine);
+                ChartData totalsData = LoadChart.LoadTotalsIntoChart(Purchase_DataGridView, PurchaseTotals_Chart, isLine);
                 string translatedExpenses = LanguageManager.TranslateString("Total expenses");
                 SetChartTitle(PurchaseTotals_Chart, $"{translatedExpenses}: {CurrencySymbol}{totalsData.Total:N2}");
 
                 if (!onlyLoadForLineCharts)
                 {
-                    LoadChart.LoadDistributionIntoChart(Purchase_DataGridView, PurchaseDistribution_Chart as PieChart, PieChartGrouping.Top12);
+                    LoadChart.LoadDistributionIntoChart(Purchase_DataGridView, PurchaseDistribution_Chart, PieChartGrouping.Top12);
                     SetChartTitle(PurchaseDistribution_Chart, TranslatedChartTitles.ExpensesDistribution);
                 }
             }
@@ -216,24 +216,31 @@ namespace Sales_Tracker
             // Load sale charts
             if (Selected == SelectedOption.Analytics || Sale_DataGridView.Visible)
             {
-                ChartData totalsData = LoadChart.LoadTotalsIntoChart(Sale_DataGridView, SaleTotals_Chart as CartesianChart, isLine);
+                ChartData totalsData = LoadChart.LoadTotalsIntoChart(Sale_DataGridView, SaleTotals_Chart, isLine);
                 string translatedRevenue = LanguageManager.TranslateString("Total revenue");
                 SetChartTitle(SaleTotals_Chart, $"{translatedRevenue}: {CurrencySymbol}{totalsData.Total:N2}");
 
                 if (!onlyLoadForLineCharts)
                 {
-                    LoadChart.LoadDistributionIntoChart(Sale_DataGridView, SaleDistribution_Chart as PieChart, PieChartGrouping.Top12);
+                    LoadChart.LoadDistributionIntoChart(Sale_DataGridView, SaleDistribution_Chart, PieChartGrouping.Top12);
                     SetChartTitle(SaleDistribution_Chart, TranslatedChartTitles.RevenueDistribution);
                 }
             }
 
             // Always load profits chart
-            ChartData profitsData = LoadChart.LoadProfitsIntoChart(Profits_Chart as CartesianChart, isLine);
+            ChartData profitsData = LoadChart.LoadProfitsIntoChart(Profits_Chart, isLine);
             SetProfitsChartTitle(profitsData.Total);
         }
-        public static void SetChartTitle(Chart chart, string title)
+        public static void SetChartTitle(Control chart, string title)
         {
-            chart.Title = CreateChartTitle(title);
+            if (chart is CartesianChart cartesianChart)
+            {
+                cartesianChart.Title = CreateChartTitle(title);
+            }
+            else if (chart is PieChart pieChart)
+            {
+                pieChart.Title = CreateChartTitle(title);
+            }
         }
         private static LabelVisual CreateChartTitle(string text) => new()
         {
@@ -1775,7 +1782,7 @@ namespace Sales_Tracker
         public Guna2DataGridView Purchase_DataGridView { get; private set; } = new();
         public Guna2DataGridView Sale_DataGridView { get; private set; } = new();
         public Guna2DataGridView SelectedDataGridView { get; private set; }
-        public Chart Profits_Chart { get; private set; }
+        public CartesianChart Profits_Chart { get; private set; }
 
         // DataGridView enums
         public enum SelectedOption
@@ -2095,26 +2102,26 @@ namespace Sales_Tracker
             PurchasesOnly,
             SalesOnly
         }
-        public Chart CountriesOfOrigin_Chart { get; private set; }
-        public Chart CountriesOfDestination_Chart { get; private set; }
-        public Chart CompaniesOfOrigin_Chart { get; private set; }
-        public Chart Accountants_Chart { get; private set; }
-        public Chart GrowthRates_Chart { get; private set; }
-        public Chart SalesVsExpenses_Chart { get; private set; }
-        public Chart AverageTransactionValue_Chart { get; private set; }
-        public Chart TotalTransactions_Chart { get; private set; }
-        public Chart AverageShippingCosts_Chart { get; private set; }
+        public PieChart CountriesOfOrigin_Chart { get; private set; }
+        public PieChart CountriesOfDestination_Chart { get; private set; }
+        public PieChart CompaniesOfOrigin_Chart { get; private set; }
+        public PieChart Accountants_Chart { get; private set; }
+        public CartesianChart GrowthRates_Chart { get; private set; }
+        public CartesianChart SalesVsExpenses_Chart { get; private set; }
+        public CartesianChart AverageTransactionValue_Chart { get; private set; }
+        public CartesianChart TotalTransactions_Chart { get; private set; }
+        public CartesianChart AverageShippingCosts_Chart { get; private set; }
         public Guna2CustomCheckBox IncludeFreeShipping_CheckBox { get; private set; }
-        public Chart ReturnsOverTime_Chart { get; private set; }
-        public Chart ReturnReasons_Chart { get; private set; }
-        public Chart ReturnFinancialImpact_Chart { get; private set; }
-        public Chart ReturnsByCategory_Chart { get; private set; }
-        public Chart ReturnsByProduct_Chart { get; private set; }
-        public Chart PurchaseVsSaleReturns_Chart { get; private set; }
-        public Chart PurchaseTotals_Chart { get; private set; }
-        public Chart PurchaseDistribution_Chart { get; private set; }
-        public Chart SaleTotals_Chart { get; private set; }
-        public Chart SaleDistribution_Chart { get; private set; }
+        public CartesianChart ReturnsOverTime_Chart { get; private set; }
+        public PieChart ReturnReasons_Chart { get; private set; }
+        public CartesianChart ReturnFinancialImpact_Chart { get; private set; }
+        public PieChart ReturnsByCategory_Chart { get; private set; }
+        public PieChart ReturnsByProduct_Chart { get; private set; }
+        public PieChart PurchaseVsSaleReturns_Chart { get; private set; }
+        public CartesianChart PurchaseTotals_Chart { get; private set; }
+        public PieChart PurchaseDistribution_Chart { get; private set; }
+        public CartesianChart SaleTotals_Chart { get; private set; }
+        public PieChart SaleDistribution_Chart { get; private set; }
 
         // GeoMap properties
         public GeoMap WorldMap_GeoMap { get; private set; }
@@ -2188,21 +2195,21 @@ namespace Sales_Tracker
         }
         private void ConstructControlsForAnalytics()
         {
-            CountriesOfOrigin_Chart = ConstructAnalyticsChart("countriesOfOrigin_Chart", false);
-            CompaniesOfOrigin_Chart = ConstructAnalyticsChart("companiesOfOrigin_Chart", false);
-            CountriesOfDestination_Chart = ConstructAnalyticsChart("countriesOfDestination_Chart", false);
-            Accountants_Chart = ConstructAnalyticsChart("accountants_Chart", false);
-            SalesVsExpenses_Chart = ConstructAnalyticsChart("salesVsExpenses_Chart", true);
-            AverageTransactionValue_Chart = ConstructAnalyticsChart("averageOrderValue_Chart", true);
-            TotalTransactions_Chart = ConstructAnalyticsChart("totalTransactions_Chart", true);
-            AverageShippingCosts_Chart = ConstructAnalyticsChart("averageShippingCosts_Chart", true);
-            GrowthRates_Chart = ConstructAnalyticsChart("growthRates_Chart", true);
-            ReturnsOverTime_Chart = ConstructAnalyticsChart("returnsOverTime_Chart", true);
-            ReturnReasons_Chart = ConstructAnalyticsChart("returnReasons_Chart", false);
-            ReturnFinancialImpact_Chart = ConstructAnalyticsChart("returnFinancialImpact_Chart", true);
-            ReturnsByCategory_Chart = ConstructAnalyticsChart("returnsByCategory_Chart", false);
-            ReturnsByProduct_Chart = ConstructAnalyticsChart("returnsByProduct_Chart", false);
-            PurchaseVsSaleReturns_Chart = ConstructAnalyticsChart("purchaseVsSaleReturns_Chart", false);
+            CountriesOfOrigin_Chart = ConstructAnalyticsChart("countriesOfOrigin_Chart", false) as PieChart;
+            CompaniesOfOrigin_Chart = ConstructAnalyticsChart("companiesOfOrigin_Chart", false) as PieChart;
+            CountriesOfDestination_Chart = ConstructAnalyticsChart("countriesOfDestination_Chart", false) as PieChart;
+            Accountants_Chart = ConstructAnalyticsChart("accountants_Chart", false) as PieChart;
+            SalesVsExpenses_Chart = ConstructAnalyticsChart("salesVsExpenses_Chart", true) as CartesianChart;
+            AverageTransactionValue_Chart = ConstructAnalyticsChart("averageOrderValue_Chart", true) as CartesianChart;
+            TotalTransactions_Chart = ConstructAnalyticsChart("totalTransactions_Chart", true) as CartesianChart;
+            AverageShippingCosts_Chart = ConstructAnalyticsChart("averageShippingCosts_Chart", true) as CartesianChart;
+            GrowthRates_Chart = ConstructAnalyticsChart("growthRates_Chart", true) as CartesianChart;
+            ReturnsOverTime_Chart = ConstructAnalyticsChart("returnsOverTime_Chart", true) as CartesianChart;
+            ReturnReasons_Chart = ConstructAnalyticsChart("returnReasons_Chart", false) as PieChart;
+            ReturnFinancialImpact_Chart = ConstructAnalyticsChart("returnFinancialImpact_Chart", true) as CartesianChart;
+            ReturnsByCategory_Chart = ConstructAnalyticsChart("returnsByCategory_Chart", false) as PieChart;
+            ReturnsByProduct_Chart = ConstructAnalyticsChart("returnsByProduct_Chart", false) as PieChart;
+            PurchaseVsSaleReturns_Chart = ConstructAnalyticsChart("purchaseVsSaleReturns_Chart", false) as PieChart;
 
             WorldMap_GeoMap = ConstructGeoMap();
             ConstructWorldMapDataControls();
@@ -2232,7 +2239,7 @@ namespace Sales_Tracker
             OrganizeChartsIntoTabs();
 
             Control[] chartsAndMaps = _analyticsControls
-                .Where(c => c is Chart || c is GeoMap)
+                .Where(c => c is CartesianChart || c is PieChart || c is GeoMap)
                 .ToArray();
 
             MouseClickChartManager.InitCharts(chartsAndMaps);
@@ -2441,16 +2448,16 @@ namespace Sales_Tracker
             switch (tabKey)
             {
                 case AnalyticsTab.Overview:
-                    LoadChart.LoadSalesVsExpensesChart(SalesVsExpenses_Chart as CartesianChart, isLine);
+                    LoadChart.LoadSalesVsExpensesChart(SalesVsExpenses_Chart, isLine);
                     SetChartTitle(SalesVsExpenses_Chart, TranslatedChartTitles.SalesVsExpenses);
 
-                    LoadChart.LoadTotalTransactionsChart(TotalTransactions_Chart as CartesianChart, isLine);
+                    LoadChart.LoadTotalTransactionsChart(TotalTransactions_Chart, isLine);
                     SetChartTitle(TotalTransactions_Chart, TranslatedChartTitles.TotalTransactions);
 
-                    LoadChart.LoadAverageTransactionValueChart(AverageTransactionValue_Chart as CartesianChart, isLine);
+                    LoadChart.LoadAverageTransactionValueChart(AverageTransactionValue_Chart, isLine);
                     SetChartTitle(AverageTransactionValue_Chart, TranslatedChartTitles.AverageTransactionValue);
 
-                    ChartData profitsData = LoadChart.LoadProfitsIntoChart(Profits_Chart as CartesianChart, isLine);
+                    ChartData profitsData = LoadChart.LoadProfitsIntoChart(Profits_Chart, isLine);
                     SetProfitsChartTitle(profitsData.Total);
                     break;
 
@@ -2458,13 +2465,13 @@ namespace Sales_Tracker
                     GeoMapDataType dataType = GetSelectedGeoMapDataType();
                     LoadChart.LoadWorldMapChart(WorldMap_GeoMap, dataType);
 
-                    LoadChart.LoadCountriesOfOriginForProductsIntoChart(CountriesOfOrigin_Chart as PieChart, PieChartGrouping.Top8);
+                    LoadChart.LoadCountriesOfOriginForProductsIntoChart(CountriesOfOrigin_Chart, PieChartGrouping.Top8);
                     SetChartTitle(CountriesOfOrigin_Chart, TranslatedChartTitles.CountriesOfOrigin);
 
-                    LoadChart.LoadCountriesOfDestinationForProductsIntoChart(CountriesOfDestination_Chart as PieChart, PieChartGrouping.Top8);
+                    LoadChart.LoadCountriesOfDestinationForProductsIntoChart(CountriesOfDestination_Chart, PieChartGrouping.Top8);
                     SetChartTitle(CountriesOfDestination_Chart, TranslatedChartTitles.CountriesOfDestination);
 
-                    LoadChart.LoadCompaniesOfOriginForProductsIntoChart(CompaniesOfOrigin_Chart as PieChart, PieChartGrouping.Top8);
+                    LoadChart.LoadCompaniesOfOriginForProductsIntoChart(CompaniesOfOrigin_Chart, PieChartGrouping.Top8);
                     SetChartTitle(CompaniesOfOrigin_Chart, TranslatedChartTitles.CompaniesOfOrigin);
                     break;
 
@@ -2473,46 +2480,46 @@ namespace Sales_Tracker
                     break;
 
                 case AnalyticsTab.Performance:
-                    LoadChart.LoadGrowthRateChart(GrowthRates_Chart as CartesianChart);
+                    LoadChart.LoadGrowthRateChart(GrowthRates_Chart);
                     SetChartTitle(GrowthRates_Chart, TranslatedChartTitles.GrowthRates);
 
                     // Load shared charts if not already loaded
                     if (!_tabChartsLoaded[AnalyticsTab.Overview])
                     {
-                        LoadChart.LoadAverageTransactionValueChart(AverageTransactionValue_Chart as CartesianChart, isLine);
+                        LoadChart.LoadAverageTransactionValueChart(AverageTransactionValue_Chart, isLine);
                         SetChartTitle(AverageTransactionValue_Chart, TranslatedChartTitles.AverageTransactionValue);
 
-                        LoadChart.LoadTotalTransactionsChart(TotalTransactions_Chart as CartesianChart, isLine);
+                        LoadChart.LoadTotalTransactionsChart(TotalTransactions_Chart, isLine);
                         SetChartTitle(TotalTransactions_Chart, TranslatedChartTitles.TotalTransactions);
                     }
                     break;
 
                 case AnalyticsTab.Operational:
-                    LoadChart.LoadAccountantsIntoChart(Accountants_Chart as PieChart, PieChartGrouping.Top8);
+                    LoadChart.LoadAccountantsIntoChart(Accountants_Chart, PieChartGrouping.Top8);
                     SetChartTitle(Accountants_Chart, TranslatedChartTitles.AccountantsTransactions);
 
-                    LoadChart.LoadAverageShippingCostsChart(AverageShippingCosts_Chart as CartesianChart, isLine,
+                    LoadChart.LoadAverageShippingCostsChart(AverageShippingCosts_Chart, isLine,
                         includeZeroShipping: IncludeFreeShipping_CheckBox.Checked);
                     SetChartTitle(AverageShippingCosts_Chart, TranslatedChartTitles.AverageShippingCosts);
                     break;
 
                 case AnalyticsTab.Returns:
-                    LoadChart.LoadReturnsOverTimeChart(ReturnsOverTime_Chart as CartesianChart, isLine);
+                    LoadChart.LoadReturnsOverTimeChart(ReturnsOverTime_Chart, isLine);
                     SetChartTitle(ReturnsOverTime_Chart, TranslatedChartTitles.ReturnsOverTime);
 
-                    LoadChart.LoadReturnReasonsChart(ReturnReasons_Chart as PieChart, PieChartGrouping.Top8);
+                    LoadChart.LoadReturnReasonsChart(ReturnReasons_Chart, PieChartGrouping.Top8);
                     SetChartTitle(ReturnReasons_Chart, TranslatedChartTitles.ReturnReasons);
 
-                    LoadChart.LoadReturnFinancialImpactChart(ReturnFinancialImpact_Chart as CartesianChart, isLine);
+                    LoadChart.LoadReturnFinancialImpactChart(ReturnFinancialImpact_Chart, isLine);
                     SetChartTitle(ReturnFinancialImpact_Chart, TranslatedChartTitles.ReturnFinancialImpact);
 
-                    LoadChart.LoadReturnsByCategoryChart(ReturnsByCategory_Chart as PieChart, PieChartGrouping.Top8);
+                    LoadChart.LoadReturnsByCategoryChart(ReturnsByCategory_Chart, PieChartGrouping.Top8);
                     SetChartTitle(ReturnsByCategory_Chart, TranslatedChartTitles.ReturnsByCategory);
 
-                    LoadChart.LoadReturnsByProductChart(ReturnsByProduct_Chart as PieChart, PieChartGrouping.Top8);
+                    LoadChart.LoadReturnsByProductChart(ReturnsByProduct_Chart, PieChartGrouping.Top8);
                     SetChartTitle(ReturnsByProduct_Chart, TranslatedChartTitles.ReturnsByProduct);
 
-                    LoadChart.LoadPurchaseVsSaleReturnsChart(PurchaseVsSaleReturns_Chart as PieChart);
+                    LoadChart.LoadPurchaseVsSaleReturnsChart(PurchaseVsSaleReturns_Chart);
                     SetChartTitle(PurchaseVsSaleReturns_Chart, TranslatedChartTitles.PurchaseVsSaleReturns);
                     break;
             }
@@ -2546,11 +2553,11 @@ namespace Sales_Tracker
             UserSettings.UpdateSetting("Include free shipping in chart", Properties.Settings.Default.IncludeFreeShipping, zeroShipping,
                 value => Properties.Settings.Default.IncludeFreeShipping = value);
 
-            LoadChart.LoadAverageShippingCostsChart(AverageShippingCosts_Chart as CartesianChart, isLineChart, includeZeroShipping: zeroShipping);
+            LoadChart.LoadAverageShippingCostsChart(AverageShippingCosts_Chart, isLineChart, includeZeroShipping: zeroShipping);
         }
-        private Chart ConstructAnalyticsChart(string name, bool isCartesian)
+        private Control ConstructAnalyticsChart(string name, bool isCartesian)
         {
-            Chart chart;
+            Control chart;
 
             if (isCartesian)
             {
@@ -2614,11 +2621,11 @@ namespace Sales_Tracker
                 {
                     case AnalyticsTab.Overview:
                     case AnalyticsTab.Performance:
-                        LoadChart.LoadSalesVsExpensesChart(SalesVsExpenses_Chart as CartesianChart, isLine);
-                        LoadChart.LoadTotalTransactionsChart(TotalTransactions_Chart as CartesianChart, isLine);
-                        LoadChart.LoadAverageTransactionValueChart(AverageTransactionValue_Chart as CartesianChart, isLine);
+                        LoadChart.LoadSalesVsExpensesChart(SalesVsExpenses_Chart, isLine);
+                        LoadChart.LoadTotalTransactionsChart(TotalTransactions_Chart, isLine);
+                        LoadChart.LoadAverageTransactionValueChart(AverageTransactionValue_Chart, isLine);
 
-                        ChartData profitsData = LoadChart.LoadProfitsIntoChart(Profits_Chart as CartesianChart, isLine);
+                        ChartData profitsData = LoadChart.LoadProfitsIntoChart(Profits_Chart, isLine);
                         SetProfitsChartTitle(profitsData.Total);
                         break;
 
@@ -2627,13 +2634,13 @@ namespace Sales_Tracker
                         break;
 
                     case AnalyticsTab.Operational:
-                        LoadChart.LoadAverageShippingCostsChart(AverageShippingCosts_Chart as CartesianChart, isLine,
+                        LoadChart.LoadAverageShippingCostsChart(AverageShippingCosts_Chart, isLine,
                             includeZeroShipping: IncludeFreeShipping_CheckBox.Checked);
                         break;
 
                     case AnalyticsTab.Returns:
-                        LoadChart.LoadReturnsOverTimeChart(ReturnsOverTime_Chart as CartesianChart, isLine);
-                        LoadChart.LoadReturnFinancialImpactChart(ReturnFinancialImpact_Chart as CartesianChart, isLine);
+                        LoadChart.LoadReturnsOverTimeChart(ReturnsOverTime_Chart, isLine);
+                        LoadChart.LoadReturnFinancialImpactChart(ReturnFinancialImpact_Chart, isLine);
                         break;
                 }
             }

--- a/Sales Tracker/Sales Tracker.csproj
+++ b/Sales Tracker/Sales Tracker.csproj
@@ -41,8 +41,8 @@
     <PackageReference Include="Google.Apis.ServiceUsage.v1" Version="1.70.0.3822" />
     <PackageReference Include="Google.Apis.Sheets.v4" Version="1.70.0.3819" />
     <PackageReference Include="Guna.UI2.WinForms" Version="2.0.4.7" />
-    <PackageReference Include="LiveChartsCore.SkiaSharpView.WinForms" Version="2.0.0-rc5.4" />
-    <PackageReference Include="NetSparkleUpdater.SparkleUpdater" Version="3.0.3" />
+    <PackageReference Include="LiveChartsCore.SkiaSharpView.WinForms" Version="2.0.0-rc6.1" />
+    <PackageReference Include="NetSparkleUpdater.SparkleUpdater" Version="3.0.4" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.4-beta1" />
     <PackageReference Include="Ookii.Dialogs.WinForms" Version="4.0.0" />
     <PackageReference Include="SharpCompress" Version="0.40.0" />


### PR DESCRIPTION
There is finally an update to the LiveCharts package, which fixed a couple issues. There's a few breaking changes in RC6.1:

1. `LiveChartsCore.Chart` is now a core model/data class, not a UI control
2. UI controls are now separate: `CartesianChart`, `PieChart`, etc. in `LiveChartsCore.SkiaSharpView.WinForms`
3. Properties like `Height`, `Width`, `Visible`, `Tag`, etc. are only available on the UI controls, not the core `Chart `class

This pull request updates our codebase to use LiveCharts RC6.1 and addresses all breaking changes.