### PR TITLE
Updated default settings and updated purchases/sales

### DIFF
--- a/Sales Tracker/AddPurchase_Form.cs
+++ b/Sales Tracker/AddPurchase_Form.cs
@@ -242,10 +242,10 @@ namespace Sales_Tracker
             string date = Tools.FormatDate(Date_DateTimePicker.Value);
             int quantity = int.Parse(Quantity_TextBox.Text);
             decimal pricePerUnit = decimal.Parse(PricePerUnit_TextBox.Text);
-            decimal shipping = decimal.Parse(Shipping_TextBox.Text);
-            decimal tax = decimal.Parse(Tax_TextBox.Text);
-            decimal fee = decimal.Parse(Fee_TextBox.Text);
-            decimal discount = decimal.Parse(Discount_TextBox.Text);
+            decimal shipping = string.IsNullOrWhiteSpace(Shipping_TextBox.Text) ? 0 : decimal.Parse(Shipping_TextBox.Text);
+            decimal tax = string.IsNullOrWhiteSpace(Tax_TextBox.Text) ? 0 : decimal.Parse(Tax_TextBox.Text);
+            decimal fee = string.IsNullOrWhiteSpace(Fee_TextBox.Text) ? 0 : decimal.Parse(Fee_TextBox.Text);
+            decimal discount = string.IsNullOrWhiteSpace(Discount_TextBox.Text) ? 0 : decimal.Parse(Discount_TextBox.Text);
             string noteLabel = ReadOnlyVariables.EmptyCell;
             string note = Notes_TextBox.Text.Trim();
             if (note != "")
@@ -399,10 +399,10 @@ namespace Sales_Tracker
             }
 
             string date = Tools.FormatDate(Date_DateTimePicker.Value);
-            decimal shipping = decimal.Parse(Shipping_TextBox.Text);
-            decimal tax = decimal.Parse(Tax_TextBox.Text);
-            decimal fee = decimal.Parse(Fee_TextBox.Text);
-            decimal discount = decimal.Parse(Discount_TextBox.Text);
+            decimal shipping = string.IsNullOrWhiteSpace(Shipping_TextBox.Text) ? 0 : decimal.Parse(Shipping_TextBox.Text);
+            decimal tax = string.IsNullOrWhiteSpace(Tax_TextBox.Text) ? 0 : decimal.Parse(Tax_TextBox.Text);
+            decimal fee = string.IsNullOrWhiteSpace(Fee_TextBox.Text) ? 0 : decimal.Parse(Fee_TextBox.Text);
+            decimal discount = string.IsNullOrWhiteSpace(Discount_TextBox.Text) ? 0 : decimal.Parse(Discount_TextBox.Text);
             string noteLabel = ReadOnlyVariables.EmptyCell;
             string note = Notes_TextBox.Text.Trim();
             if (note != "")
@@ -1027,10 +1027,6 @@ namespace Sales_Tracker
         private void ValidateInputs(object sender, EventArgs e)
         {
             bool allFieldsFilled = !string.IsNullOrWhiteSpace(OrderNumber_TextBox.Text) &&
-                !string.IsNullOrWhiteSpace(Shipping_TextBox.Text) &&
-                !string.IsNullOrWhiteSpace(Tax_TextBox.Text) &&
-                !string.IsNullOrWhiteSpace(Fee_TextBox.Text) &&
-                !string.IsNullOrWhiteSpace(Discount_TextBox.Text) &&
                 !string.IsNullOrWhiteSpace(Charged_TextBox.Text);
 
             if (Properties.Settings.Default.PurchaseReceipts)

--- a/Sales Tracker/AddSale_Form.cs
+++ b/Sales Tracker/AddSale_Form.cs
@@ -235,6 +235,7 @@ namespace Sales_Tracker
 
             // Get values from TextBoxes
             string[] items = ProductName_TextBox.Text.Split('>');
+
             string companyName = items[0].Trim();
             string categoryName = items[1].Trim();
             string productName = items[2].Trim();
@@ -243,10 +244,10 @@ namespace Sales_Tracker
             string date = Tools.FormatDate(Date_DateTimePicker.Value);
             int quantity = int.Parse(Quantity_TextBox.Text);
             decimal pricePerUnit = decimal.Parse(PricePerUnit_TextBox.Text);
-            decimal shipping = decimal.Parse(Shipping_TextBox.Text);
-            decimal tax = decimal.Parse(Tax_TextBox.Text);
-            decimal fee = decimal.Parse(Fee_TextBox.Text);
-            decimal discount = decimal.Parse(Discount_TextBox.Text);
+            decimal shipping = string.IsNullOrWhiteSpace(Shipping_TextBox.Text) ? 0 : decimal.Parse(Shipping_TextBox.Text);
+            decimal tax = string.IsNullOrWhiteSpace(Tax_TextBox.Text) ? 0 : decimal.Parse(Tax_TextBox.Text);
+            decimal fee = string.IsNullOrWhiteSpace(Fee_TextBox.Text) ? 0 : decimal.Parse(Fee_TextBox.Text);
+            decimal discount = string.IsNullOrWhiteSpace(Discount_TextBox.Text) ? 0 : decimal.Parse(Discount_TextBox.Text);
             decimal totalPrice = Math.Round(quantity * pricePerUnit - discount, 2);
             string noteLabel = ReadOnlyVariables.EmptyCell;
             string note = Notes_TextBox.Text.Trim();
@@ -387,10 +388,10 @@ namespace Sales_Tracker
 
             // Get values from TextBoxes
             string date = Tools.FormatDate(Date_DateTimePicker.Value);
-            decimal shipping = decimal.Parse(Shipping_TextBox.Text);
-            decimal tax = decimal.Parse(Tax_TextBox.Text);
-            decimal fee = decimal.Parse(Fee_TextBox.Text);
-            decimal discount = decimal.Parse(Discount_TextBox.Text);
+            decimal shipping = string.IsNullOrWhiteSpace(Shipping_TextBox.Text) ? 0 : decimal.Parse(Shipping_TextBox.Text);
+            decimal tax = string.IsNullOrWhiteSpace(Tax_TextBox.Text) ? 0 : decimal.Parse(Tax_TextBox.Text);
+            decimal fee = string.IsNullOrWhiteSpace(Fee_TextBox.Text) ? 0 : decimal.Parse(Fee_TextBox.Text);
+            decimal discount = string.IsNullOrWhiteSpace(Discount_TextBox.Text) ? 0 : decimal.Parse(Discount_TextBox.Text);
             string noteLabel = ReadOnlyVariables.EmptyCell;
             string note = Notes_TextBox.Text.Trim();
             if (note != "")
@@ -1004,11 +1005,7 @@ namespace Sales_Tracker
         private void ValidateInputs(object sender, EventArgs e)
         {
             bool allFieldsFilled = !string.IsNullOrWhiteSpace(SaleNumber_TextBox.Text) &&
-                !string.IsNullOrWhiteSpace(Shipping_TextBox.Text) &&
-                !string.IsNullOrWhiteSpace(Tax_TextBox.Text) &&
-                !string.IsNullOrWhiteSpace(Fee_TextBox.Text) &&
                 !string.IsNullOrWhiteSpace(CountryOfDestinaion_TextBox.Text) && CountryOfDestinaion_TextBox.Tag.ToString() != "0" &&
-                !string.IsNullOrWhiteSpace(Discount_TextBox.Text) &&
                 !string.IsNullOrWhiteSpace(Credited_TextBox.Text);
 
             if (Properties.Settings.Default.SaleReceipts)

--- a/Sales Tracker/App.config
+++ b/Sales Tracker/App.config
@@ -25,13 +25,7 @@
             <setting name="SendAnonymousInformation" serializeAs="String">
                 <value>True</value>
             </setting>
-            <setting name="PurchaseReceipts" serializeAs="String">
-                <value>True</value>
-            </setting>
             <setting name="EncryptFiles" serializeAs="String">
-                <value>True</value>
-            </setting>
-            <setting name="SaleReceipts" serializeAs="String">
                 <value>True</value>
             </setting>
             <setting name="ShowTooltips" serializeAs="String">
@@ -63,6 +57,12 @@
             </setting>
             <setting name="CompanyLogoPath" serializeAs="String">
                 <value />
+            </setting>
+            <setting name="PurchaseReceipts" serializeAs="String">
+                <value>False</value>
+            </setting>
+            <setting name="SaleReceipts" serializeAs="String">
+                <value>False</value>
             </setting>
         </Sales_Tracker.Properties.Settings>
     </userSettings>

--- a/Sales Tracker/Properties/Settings.Designer.cs
+++ b/Sales Tracker/Properties/Settings.Designer.cs
@@ -97,7 +97,7 @@ namespace Sales_Tracker.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool PurchaseReceipts {
             get {
                 return ((bool)(this["PurchaseReceipts"]));
@@ -121,7 +121,7 @@ namespace Sales_Tracker.Properties {
         
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
-        [global::System.Configuration.DefaultSettingValueAttribute("True")]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
         public bool SaleReceipts {
             get {
                 return ((bool)(this["SaleReceipts"]));

--- a/Sales Tracker/Properties/Settings.settings
+++ b/Sales Tracker/Properties/Settings.settings
@@ -21,13 +21,13 @@
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="PurchaseReceipts" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
+      <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="EncryptFiles" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
     <Setting Name="SaleReceipts" Type="System.Boolean" Scope="User">
-      <Value Profile="(Default)">True</Value>
+      <Value Profile="(Default)">False</Value>
     </Setting>
     <Setting Name="ShowTooltips" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>


### PR DESCRIPTION
Default settings now do not require reciepts for purchases and sales.  Shipping, taxes, fees, and discounts are no longer mandatory and the value will be 0 when left blank.  Closes #317 