### PR TITLE
Fix: Track 'bring to front' and 'send to back' in undo/redo system

### DIFF
--- a/Sales Tracker/ReportGenerator/Menus/ReportLayoutDesigner_Form.cs
+++ b/Sales Tracker/ReportGenerator/Menus/ReportLayoutDesigner_Form.cs
@@ -1447,12 +1447,20 @@ namespace Sales_Tracker.ReportGenerator.Menus
 
             if (elementsToMove.Count == 0) { return; }
 
+            // Create undo action before making changes
+            string description = elementsToMove.Count == 1 ? "Bring to front" : $"Bring {elementsToMove.Count} elements to front";
+            LayerOrderAction action = new(ReportConfig.Elements.ToList(), elementsToMove, description, RefreshCanvas);
+
             int maxZOrder = ReportConfig.Elements.Max(e => e.ZOrder);
 
             foreach (BaseElement element in elementsToMove.OrderBy(e => e.ZOrder))
             {
                 element.ZOrder = ++maxZOrder;
             }
+
+            // Capture the new state and record the action
+            action.CaptureNewState(ReportConfig.Elements.ToList());
+            _undoRedoManager.RecordAction(action);
 
             Canvas_Panel.Invalidate();
         }
@@ -1467,6 +1475,10 @@ namespace Sales_Tracker.ReportGenerator.Menus
 
             if (elementsToMove.Count == 0) { return; }
 
+            // Create undo action before making changes
+            string description = elementsToMove.Count == 1 ? "Send to back" : $"Send {elementsToMove.Count} elements to back";
+            LayerOrderAction action = new(ReportConfig.Elements.ToList(), elementsToMove, description, RefreshCanvas);
+
             // Shift all non-selected elements up
             int shiftAmount = elementsToMove.Count;
             foreach (BaseElement element in ReportConfig.Elements.Where(e => !elementsToMove.Contains(e)))
@@ -1480,6 +1492,10 @@ namespace Sales_Tracker.ReportGenerator.Menus
             {
                 element.ZOrder = zOrder++;
             }
+
+            // Capture the new state and record the action
+            action.CaptureNewState(ReportConfig.Elements.ToList());
+            _undoRedoManager.RecordAction(action);
 
             Canvas_Panel.Invalidate();
         }

--- a/Sales Tracker/ReportGenerator/UndoRedoManager.cs
+++ b/Sales Tracker/ReportGenerator/UndoRedoManager.cs
@@ -566,4 +566,61 @@ namespace Sales_Tracker.ReportGenerator
             _refreshCanvas();
         }
     }
+
+    /// <summary>
+    /// Action for changing element layer order (bring to front / send to back).
+    /// </summary>
+    public class LayerOrderAction : IUndoableAction
+    {
+        private readonly Dictionary<BaseElement, int> _oldZOrders;
+        private readonly Dictionary<BaseElement, int> _newZOrders;
+        private readonly string _description;
+        private readonly Action _refreshCanvas;
+
+        public LayerOrderAction(List<BaseElement> allElements, List<BaseElement> affectedElements, string description, Action refreshCanvas)
+        {
+            _oldZOrders = [];
+            _newZOrders = [];
+            _description = description;
+            _refreshCanvas = refreshCanvas;
+
+            // Store old Z-orders for all elements
+            foreach (BaseElement element in allElements)
+            {
+                _oldZOrders[element] = element.ZOrder;
+            }
+        }
+
+        /// <summary>
+        /// Captures the new Z-orders after the operation has been performed.
+        /// This should be called after the layer order change is applied.
+        /// </summary>
+        public void CaptureNewState(List<BaseElement> allElements)
+        {
+            foreach (BaseElement element in allElements)
+            {
+                _newZOrders[element] = element.ZOrder;
+            }
+        }
+
+        public string Description => _description;
+
+        public void Undo()
+        {
+            foreach (KeyValuePair<BaseElement, int> kvp in _oldZOrders)
+            {
+                kvp.Key.ZOrder = kvp.Value;
+            }
+            _refreshCanvas();
+        }
+
+        public void Redo()
+        {
+            foreach (KeyValuePair<BaseElement, int> kvp in _newZOrders)
+            {
+                kvp.Key.ZOrder = kvp.Value;
+            }
+            _refreshCanvas();
+        }
+    }
 }


### PR DESCRIPTION
Added LayerOrderAction class to track layer order changes in the report generator. This enables users to undo/redo 'bring to front' and 'send to back' operations.

Changes:
- Created LayerOrderAction class in UndoRedoManager.cs
- Updated BringElementToFront() to record undo actions
- Updated SendElementToBack() to record undo actions

🤖 Generated with [Claude Code](https://claude.com/claude-code)