### PR TITLE
Fix: Prevent updating built-in templates when saving

### DIFF
--- a/Sales Tracker/ReportGenerator/Menus/ReportLayoutDesigner_Form.cs
+++ b/Sales Tracker/ReportGenerator/Menus/ReportLayoutDesigner_Form.cs
@@ -2311,9 +2311,16 @@ namespace Sales_Tracker.ReportGenerator.Menus
         // Template save/load functionality
         private void SaveTemplate_Button_Click(object sender, EventArgs e)
         {
+            // For built-in templates, don't allow updating - only save as new
+            string currentTemplateForSave = _currentTemplateName;
+            if (!string.IsNullOrEmpty(_currentTemplateName) && ReportTemplates.IsBuiltInTemplate(_currentTemplateName))
+            {
+                currentTemplateForSave = null;
+            }
+
             using SaveTemplate_Form form = new()
             {
-                CurrentTemplateName = _currentTemplateName
+                CurrentTemplateName = currentTemplateForSave
             };
 
             if (form.ShowDialog() == DialogResult.OK && !string.IsNullOrEmpty(form.TemplateName))


### PR DESCRIPTION
Built-in templates can now only be saved as new custom templates. When a built-in template is loaded and the user clicks save, the save dialog will only show the "Save as New" option instead of offering to update the existing built-in template.

This prevents users from accidentally attempting to overwrite built-in templates, which could cause confusion.