### PR TITLE
Fix: Preserve template state after saving built-in template as new

### DIFF
--- a/Sales Tracker/ReportGenerator/Menus/CustomTemplateManager_Form.cs
+++ b/Sales Tracker/ReportGenerator/Menus/CustomTemplateManager_Form.cs
@@ -229,7 +229,7 @@ namespace Sales_Tracker.ReportGenerator.Menus
             {
                 LoadTemplates();
                 UpdateButtonStates();
-                ReportDataSelection_Form.Instance.RefreshTemplates();
+                ReportDataSelection_Form.Instance.RefreshTemplates(newTemplateName);
 
                 // Select the renamed template
                 int index = _templateNames.IndexOf(newTemplateName);
@@ -401,7 +401,7 @@ namespace Sales_Tracker.ReportGenerator.Menus
                 // Reload templates and refresh UI
                 LoadTemplates();
                 UpdateButtonStates();
-                ReportDataSelection_Form.Instance.RefreshTemplates();
+                ReportDataSelection_Form.Instance.RefreshTemplates(importedTemplateName);
 
                 // Select the imported template
                 int index = _templateNames.IndexOf(importedTemplateName);

--- a/Sales Tracker/ReportGenerator/Menus/ReportDataSelection_Form.cs
+++ b/Sales Tracker/ReportGenerator/Menus/ReportDataSelection_Form.cs
@@ -176,12 +176,34 @@ namespace Sales_Tracker.ReportGenerator.Menus
                 _previousTemplateIndex = 0;
             });
         }
-        public void RefreshTemplates()
+        public void RefreshTemplates(string selectTemplateName = null)
         {
             int previousIndex = Template_ComboBox.SelectedIndex;
             SetupTemplates();
 
-            // Try to restore previous selection if still valid
+            // If a specific template name is provided, select it
+            if (!string.IsNullOrEmpty(selectTemplateName))
+            {
+                int newIndex = -1;
+                for (int i = 0; i < Template_ComboBox.Items.Count; i++)
+                {
+                    if (Template_ComboBox.Items[i].ToString() == selectTemplateName)
+                    {
+                        newIndex = i;
+                        break;
+                    }
+                }
+
+                if (newIndex >= 0)
+                {
+                    // Update previous index BEFORE setting selected index to prevent reload
+                    _previousTemplateIndex = newIndex;
+                    Template_ComboBox.SelectedIndex = newIndex;
+                    return;
+                }
+            }
+
+            // Otherwise, try to restore previous selection if still valid
             if (previousIndex >= 0 && previousIndex < Template_ComboBox.Items.Count)
             {
                 Template_ComboBox.SelectedIndex = previousIndex;

--- a/Sales Tracker/ReportGenerator/Menus/ReportLayoutDesigner_Form.cs
+++ b/Sales Tracker/ReportGenerator/Menus/ReportLayoutDesigner_Form.cs
@@ -2331,8 +2331,8 @@ namespace Sales_Tracker.ReportGenerator.Menus
                     _undoRedoManager.MarkSaved();  // Mark this as the saved state
                     SetUnsavedChanges(false);
 
-                    // Refresh the template list in the data selection form
-                    ReportDataSelection_Form.Instance?.RefreshTemplates();
+                    // Refresh the template list and select the newly saved template
+                    ReportDataSelection_Form.Instance?.RefreshTemplates(form.TemplateName);
                 }
                 else
                 {


### PR DESCRIPTION
Fixed two issues when saving a built-in template with a new name:
1. Date range and other settings were being lost
2. The dropdown would show the old built-in template instead of the new saved template

Root Cause:
- After saving, RefreshTemplates() was restoring the previous dropdown index
- This triggered template reload via ApplyTemplateByIndex, overwriting the saved state
- The old built-in template would reload, losing all current settings

Solution:
- Modified RefreshTemplates to accept an optional template name parameter
- When provided, it finds and selects that template by name
- Sets _previousTemplateIndex BEFORE changing SelectedIndex to prevent reload
- Template_ComboBox_SelectedIndexChanged checks if index changed and returns early
- Updated save/rename/import operations to pass the new template name

Files Modified:
- ReportDataSelection_Form.cs: Enhanced RefreshTemplates method
- ReportLayoutDesigner_Form.cs: Pass new template name after save
- CustomTemplateManager_Form.cs: Pass template name after rename/import