### PR TITLE
Fix rental item deletion not persisting

### DIFF
--- a/Sales Tracker/GridView/DataGridViewManager.cs
+++ b/Sales Tracker/GridView/DataGridViewManager.cs
@@ -362,8 +362,17 @@ namespace Sales_Tracker.GridView
         }
         private static void HandleRentalsDeletion(DataGridViewRowCancelEventArgs e)
         {
-            string columnName = Rentals_Form.Column.ProductName.ToString();
-            string name = e.Row.Cells[columnName].Value?.ToString();
+            string rentalItemIDColumn = Rentals_Form.Column.RentalItemID.ToString();
+            string rentalItemID = e.Row.Cells[rentalItemIDColumn].Value?.ToString();
+
+            string productNameColumn = Rentals_Form.Column.ProductName.ToString();
+            string name = e.Row.Cells[productNameColumn].Value?.ToString();
+
+            // Actually remove the item from the rental inventory
+            if (!string.IsNullOrEmpty(rentalItemID))
+            {
+                RentalInventoryManager.RemoveRentalItem(rentalItemID);
+            }
 
             string message = $"Deleted rental '{name}'";
             CustomMessage_Form.AddThingThatHasChangedAndLogMessage(MainMenu_Form.ThingsThatHaveChangedInFile, 2, message);


### PR DESCRIPTION
Fixed bug where deleting a rental item from inventory would only remove it from the UI but not from the underlying data structure. When the company was saved and reopened, the deleted item would reappear.

The HandleRentalsDeletion method now:
- Extracts the RentalItemID from the deleted row
- Calls RentalInventoryManager.RemoveRentalItem() to properly remove the item
- The RemoveRentalItem method handles both removing from the in-memory list and saving to the file

This matches the pattern used in other deletion handlers like HandleProductPurchasesDeletion and HandleProductSalesDeletion.